### PR TITLE
Huggingface integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ kornia
 timm
 opencv-python
 gradio
+huggingface_hub >=0.22

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ import torch.optim as optim
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from torch.utils.data import DataLoader
+from huggingface_hub import PyTorchModelHubMixin
 
 from data_loader import create_training_datasets
 from model import ISNetDIS, ISNetGTEncoder, U2NET, U2NET_full2, U2NET_lite2, MODNet \
@@ -56,7 +57,12 @@ def f1_torch(pred, gt):
     return precision, recall, f1
 
 
-class AnimeSegmentation(pl.LightningModule):
+class AnimeSegmentation(pl.LightningModule,
+                        PyTorchModelHubMixin,
+                        library_name="anime_segmentation",
+                        repo_url="https://github.com/SkyTNT/anime-segmentation",
+                        tags=["image-segmentation"]
+                        ):
 
     def __init__(self, net_name, img_size=None, lr=1e-3):
         super().__init__()

--- a/train.py
+++ b/train.py
@@ -36,7 +36,7 @@ def get_net(net_name, img_size):
         return InSPyReNet_Res2Net50(base_size=img_size)
     elif net_name == "inspyrnet_swin":
         return InSPyReNet_SwinB(base_size=img_size)
-    raise NotImplemented
+    raise NotImplementedError
 
 
 def f1_torch(pred, gt):
@@ -104,7 +104,7 @@ class AnimeSegmentation(pl.LightningModule,
             return self.net(x, True)[2]
         elif isinstance(self.net, InSPyReNet):
             return self.net.forward_inference(x)["pred"]
-        raise NotImplemented
+        raise NotImplementedError
 
     def training_step(self, batch, batch_idx):
         images, labels = batch["image"], batch["label"]
@@ -128,7 +128,7 @@ class AnimeSegmentation(pl.LightningModule,
             out = self.net.forward_train(images, labels)
             loss_args = out
         else:
-            raise NotImplemented
+            raise NotImplementedError
 
         loss0, loss = self.net.compute_loss(loss_args)
         self.log_dict({"train/loss": loss, "train/loss_tar": loss0})


### PR DESCRIPTION
Hi @SkyTNT 
This pr will allow your model to be integrated with huggingface.
By inheriting from **PyTorchModelHubMixin** your model will get 3 methods similar to how the transformers library works which are 
* save_pretrained
* from_pretrained
* push_to_hub

To help you setup your repo on the hub I have made this [colab notebook](https://colab.research.google.com/drive/1x07ib7vPVq9cEait9Cf7-7IEQLzeBbo0?usp=sharing) to help you equip your previous weights with PyTorchModelHubMixin. 

By using the mixin class you also get : 
* the download metrics enabled on the hub and see how many times your model has been downloaded per month
* it will also automatically convert you model to a `safetensors` format for safer and faster loading of your checkpoints. 
* the Mixin will also automatically generate a model card for you where the metadata in the card allows you to filter your searches to find all other `anime_segmentation` models or use any other tags that you want since this is fully customizable (example : https://huggingface.co/models?other=anime_segmentation) 
* (extra) : if you want to integrate your model with pip I made a little template for that in this repo : https://github.com/not-lain/PyTorchModelHubMixin-template 

Do not hesitate if you have any reviews on the pr or any questions.

Kind regards,
Hafedh Hichri (Lain)