### PR TITLE
Permit variable batch size for exported onnx file

### DIFF
--- a/export.py
+++ b/export.py
@@ -1,4 +1,5 @@
 import argparse
+
 import torch
 
 from train import AnimeSegmentation, net_names
@@ -7,41 +8,58 @@ from train import AnimeSegmentation, net_names
 def export_onnx(model, img_size, path):
     import onnx
     from onnxsim import simplify
-    torch.onnx.export(model,  # model being run
-                      torch.randn(1, 3, img_size, img_size),  # model input (or a tuple for multiple inputs)
-                      path,  # where to save the model (can be a file or file-like object)
-                      export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=11,  # the ONNX version to export the model to
-                      do_constant_folding=True,  # whether to execute constant folding for optimization
-                      input_names=["img"],  # the model's input names
-                      output_names=["mask"],  # the model's output names
-                      verbose=True
-                      )
+
+    torch.onnx.export(
+        model,  # model being run
+        torch.randn(
+            1, 3, img_size, img_size
+        ),  # model input (or a tuple for multiple inputs)
+        path,  # where to save the model (can be a file or file-like object)
+        export_params=True,  # store the trained parameter weights inside the model file
+        opset_version=11,  # the ONNX version to export the model to
+        do_constant_folding=True,  # whether to execute constant folding for optimization
+        input_names=["img"],  # the model's input names
+        output_names=["mask"],  # the model's output names
+        dynamic_axes={
+            "img": {0: "batch_size"},  # variable length axes
+            "mask": {0: "batch_size"},
+        },
+        verbose=True,
+    )
     onnx_model = onnx.load(path)
     model_simp, check = simplify(onnx_model)
     assert check, "Simplified ONNX model could not be validated"
     onnx.save(model_simp, path)
-    print('finished exporting onnx')
+    print("finished exporting onnx")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # model args
-    parser.add_argument('--net', type=str, default='isnet_is',
-                        choices=net_names,
-                        help='net name')
-    parser.add_argument('--ckpt', type=str, default='saved_models/isnetis.ckpt',
-                        help='model checkpoint path')
-    parser.add_argument('--out', type=str, default='saved_models/isnetis.onnx',
-                        help='output path')
-    parser.add_argument('--to', type=str, default='onnx', choices=["only_state_dict", "only_net_state_dict", "onnx"],
-                        help='export to ()')
-    parser.add_argument('--img-size', type=int, default=1024,
-                        help='input image size')
+    parser.add_argument(
+        "--net", type=str, default="isnet_is", choices=net_names, help="net name"
+    )
+    parser.add_argument(
+        "--ckpt",
+        type=str,
+        default="saved_models/isnetis.ckpt",
+        help="model checkpoint path",
+    )
+    parser.add_argument(
+        "--out", type=str, default="saved_models/isnetis.onnx", help="output path"
+    )
+    parser.add_argument(
+        "--to",
+        type=str,
+        default="onnx",
+        choices=["only_state_dict", "only_net_state_dict", "onnx"],
+        help="export to ()",
+    )
+    parser.add_argument("--img-size", type=int, default=1024, help="input image size")
     opt = parser.parse_args()
     print(opt)
 
-    model = AnimeSegmentation.try_load(opt.net, opt.ckpt, "cpu",img_size=opt.img_size)
+    model = AnimeSegmentation.try_load(opt.net, opt.ckpt, "cpu", img_size=opt.img_size)
     model.eval()
     if opt.to == "only_state_dict":
         torch.save(model.state_dict(), opt.out)


### PR DESCRIPTION
This change allows onnx files created with `export.py` to perform batched inference. The following batched inference script fails with the current exported onnx files, but works for onnx files created with the modified export script:
```
import argparse
import os
from pathlib import Path

import cv2
import numpy as np
import onnxruntime as ort
from tqdm import tqdm


def preprocess_image(img_path, img_size):
    # Read image
    img = cv2.imread(img_path)
    if img is None:
        raise ValueError(f"Could not read image at {img_path}")

    # Convert BGR to RGB
    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

    # Get original dimensions
    h, w = img.shape[:2]

    # Calculate new dimensions maintaining aspect ratio
    if h > w:
        new_h, new_w = img_size, int(img_size * w / h)
    else:
        new_h, new_w = int(img_size * h / w), img_size

    # Calculate padding
    ph, pw = img_size - new_h, img_size - new_w

    # Resize image
    img_resized = cv2.resize(img, (new_w, new_h))

    # Create padded image
    img_padded = np.zeros((img_size, img_size, 3), dtype=np.float32)
    img_padded[ph // 2 : ph // 2 + new_h, pw // 2 : pw // 2 + new_w] = img_resized

    # Normalize and transpose for ONNX input
    img_input = img_padded.astype(np.float32) / 255.0
    img_input = np.transpose(img_input, (2, 0, 1))

    return img_input, (h, w), (ph, pw, new_h, new_w)


def postprocess_mask(mask, original_size, padding_info):
    h, w = original_size
    ph, pw, new_h, new_w = padding_info

    # Remove padding and resize to original size
    mask = mask[0, ph // 2 : ph // 2 + new_h, pw // 2 : pw // 2 + new_w]
    mask = cv2.resize(mask, (w, h))

    return mask


def process_batch(session, input_name, image_paths, img_size, output_dir):
    # Preprocess all images in the batch
    batch_inputs = []
    original_sizes = []
    padding_infos = []

    for img_path in image_paths:
        img_input, orig_size, pad_info = preprocess_image(img_path, img_size)
        batch_inputs.append(img_input)
        original_sizes.append(orig_size)
        padding_infos.append(pad_info)

    # Stack inputs into a batch
    batch_input = np.stack(batch_inputs, axis=0)

    # Run inference
    batch_masks = session.run(None, {input_name: batch_input})[0]

    # Process each mask in the batch
    for i, (mask, img_path) in enumerate(zip(batch_masks, image_paths)):
        # Postprocess mask
        mask = postprocess_mask(mask, original_sizes[i], padding_infos[i])

        # Save mask
        output_path = os.path.join(output_dir, f"{Path(img_path).stem}_mask.png")
        cv2.imwrite(output_path, (mask * 255).astype(np.uint8))


def main():
    parser = argparse.ArgumentParser(
        description="Test ONNX model for anime segmentation"
    )
    parser.add_argument(
        "--model",
        type=str,
        help="Path to ONNX model",
        required=True,
    )
    parser.add_argument(
        "--input-dir", type=str, required=True, help="Directory containing input images"
    )
    parser.add_argument(
        "--output-dir",
        type=str,
        default="output",
        help="Directory to save output masks",
    )
    parser.add_argument(
        "--batch-size", type=int, default=4, help="Batch size for processing"
    )
    parser.add_argument("--img-size", type=int, default=1024, help="Input image size")
    args = parser.parse_args()

    # Create output directory if it doesn't exist
    os.makedirs(args.output_dir, exist_ok=True)

    # Create ONNX Runtime session
    session = ort.InferenceSession(args.model)

    # Get input name
    input_name = session.get_inputs()[0].name

    # Get all image files in the input directory
    image_extensions = (".png", ".jpg", ".jpeg", ".bmp", ".tiff")
    image_paths = [
        os.path.join(args.input_dir, f)
        for f in os.listdir(args.input_dir)
        if f.lower().endswith(image_extensions)
    ]

    # Process images in batches
    for i in tqdm(range(0, len(image_paths), args.batch_size)):
        batch_paths = image_paths[i : i + args.batch_size]
        process_batch(session, input_name, batch_paths, args.img_size, args.output_dir)

    print(f"Processed {len(image_paths)} images. Masks saved to {args.output_dir}")


if __name__ == "__main__":
    main()
```